### PR TITLE
Add rabbitmq dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,12 @@ define PROJECT_APP_EXTRA_KEYS
 	{broker_version_requirements, []}
 endef
 
-DEPS = amqp_client
+DEPS = amqp_client rabbit
 TEST_DEPS = amqp_client rabbitmq_ct_helpers rabbitmq_ct_client_helpers gun
 LOCAL_DEPS = public_key crypto ssl inets
 
-dep_amqp_client = git https://github.com/rabbitmq/rabbitmq-erlang-client rabbitmq_v3_6_5
+dep_amqp_client = git https://github.com/rabbitmq/rabbitmq-erlang-client stable
+dep_rabbit = git https://github.com/rabbitmq/rabbitmq-server stable
 
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 

--- a/src/rabbit_vshovel_worker.erl
+++ b/src/rabbit_vshovel_worker.erl
@@ -306,7 +306,7 @@ publish(Tag, Method, Msg, State = #state{inbound_ch = InboundChan,
       end).
 
 make_conn_and_chan(URIs) ->
-    URI = lists:nth(random:uniform(length(URIs)), URIs),
+    URI = lists:nth(rand_compat:uniform(length(URIs)), URIs),
     {ok, AmqpParam} = amqp_uri:parse(URI),
     {ok, Conn} = amqp_connection:start(AmqpParam),
     link(Conn),


### PR DESCRIPTION
- Add  `rabbit` dependency, so it is possible to execute:`make run-broker`
- Change git branch to `stable` ( we should always `stable` as reference, and not a specific version)
- Change `random` function ( note for `3.6.x` we should not use `random`, `ssl` and `time` functions directly but use the `compat`modules: [rand_compat](https://github.com/rabbitmq/rabbitmq-common/blob/stable/src/rand_compat.erl) ,[ssl_compact](https://github.com/rabbitmq/rabbitmq-common/blob/stable/src/ssl_compat.erl), [time_compact](https://github.com/rabbitmq/rabbitmq-common/blob/stable/src/time_compat.erl)  )

